### PR TITLE
Disable building C++ unittests (NFC)

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,5 +19,9 @@ export TRITON_CUPTI_PATH=$PREFIX
 
 export MAX_JOBS=$CPU_COUNT
 
+# the build does not run C++ unittests, and they implicitly fetch gtest
+# no easy way of passing this, not really worth a whole patch
+sed -i -e '/TRITON_BUILD_UT/s:\bON:OFF:' CMakeLists.txt
+
 cd python
 $PYTHON -m pip install . -vv


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Disable building C++ unittests, since they are not run.  Furthermore, they cause googletest to be implicitly git cloned (which breaks building with rattler-build).

----

I've split this from rattler-build conversion primarily to see if CI runs out of space here too.