### PR TITLE
Update repo URL from openai to triton-lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ About triton-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/triton-feedstock/blob/main/LICENSE.txt)
 
-Home: https://github.com/openai/triton
+Home: https://github.com/triton-lang/triton
 
 Package license: MIT
 
 Summary: Development repository for the Triton language and compiler
 
-Development: https://github.com/openai/triton
+Development: https://github.com/triton-lang/triton
 
 Documentation: https://triton-lang.org/
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -6,7 +6,7 @@ context:
   # https://github.com/pytorch/pytorch/blob/v{{ pytorch_ver }}/.ci/docker/ci_commit_pins/triton.txt
   # can be found on one of those release branches, and use that as the version
   git_commit: 5fe38ffd73c2ac6ed6323b554205186696631c6f
-  build_number: 5
+  build_number: 4
 
 package:
   name: triton

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -6,7 +6,7 @@ context:
   # https://github.com/pytorch/pytorch/blob/v{{ pytorch_ver }}/.ci/docker/ci_commit_pins/triton.txt
   # can be found on one of those release branches, and use that as the version
   git_commit: 5fe38ffd73c2ac6ed6323b554205186696631c6f
-  build_number: 4
+  build_number: 5
 
 package:
   name: triton

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/openai/triton/archive/${{ git_commit }}.tar.gz
+  url: https://github.com/triton-lang/triton/archive/${{ git_commit }}.tar.gz
   sha256: 933babc32b69872efbce05fe8be61129fecf52c724fadea42d8c7b2d10e16ad9
   patches:
     - patches/0001-Remove-Werror-that-cause-false-positive-build-failur.patch
@@ -102,7 +102,7 @@ tests:
             - scipy
         script:
           # test suite essentially depends on availability of a physical GPU,
-          # see https://github.com/openai/triton/issues/466;
+          # see https://github.com/triton-lang/triton/issues/466;
           # run a test that does not require a GPU but checks
           # if triton.compile() works
           - pytest -v python/test/unit/tools/test_aot.py::test_ttgir_to_ptx
@@ -114,8 +114,8 @@ about:
   description: |
     This is the development repository of Triton, a language and compiler for writing highly efficient custom Deep-Learning primitives.
     The aim of Triton is to provide an open-source environment to write fast code at higher productivity than CUDA, but also with higher flexibility than other existing DSLs.
-  homepage: https://github.com/openai/triton
-  repository: https://github.com/openai/triton
+  homepage: https://github.com/triton-lang/triton
+  repository: https://github.com/triton-lang/triton
   documentation: https://triton-lang.org/
 
 extra:


### PR DESCRIPTION
I'm not sure when it happened, but the GitHub repository organization name was changed from 'openai' to 'triton-lang'. To avoid any confusion (which I had initially), I updated the URL accordingly.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
