### PR TITLE
backport fix for missing PY_SSIZE_T_CLEAN macro

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,44 +8,44 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython:
-        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython
+      linux_64_cuda_compiler_version12.6python3.10.____cpython:
+        CONFIG: linux_64_cuda_compiler_version12.6python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython:
-        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython
+      linux_64_cuda_compiler_version12.6python3.11.____cpython:
+        CONFIG: linux_64_cuda_compiler_version12.6python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython:
-        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython
+      linux_64_cuda_compiler_version12.6python3.12.____cpython:
+        CONFIG: linux_64_cuda_compiler_version12.6python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313:
-        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313
+      linux_64_cuda_compiler_version12.6python3.13.____cp313:
+        CONFIG: linux_64_cuda_compiler_version12.6python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.9.____cpython:
-        CONFIG: linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.9.____cpython
+      linux_64_cuda_compiler_version12.6python3.9.____cpython:
+        CONFIG: linux_64_cuda_compiler_version12.6python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython:
-        CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython
+      linux_aarch64_cuda_compiler_version12.6python3.10.____cpython:
+        CONFIG: linux_aarch64_cuda_compiler_version12.6python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython:
-        CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython
+      linux_aarch64_cuda_compiler_version12.6python3.11.____cpython:
+        CONFIG: linux_aarch64_cuda_compiler_version12.6python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython:
-        CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython
+      linux_aarch64_cuda_compiler_version12.6python3.12.____cpython:
+        CONFIG: linux_aarch64_cuda_compiler_version12.6python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313:
-        CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313
+      linux_aarch64_cuda_compiler_version12.6python3.13.____cp313:
+        CONFIG: linux_aarch64_cuda_compiler_version12.6python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.9.____cpython:
-        CONFIG: linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.9.____cpython
+      linux_aarch64_cuda_compiler_version12.6python3.9.____cpython:
+        CONFIG: linux_aarch64_cuda_compiler_version12.6python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_cuda_compiler_version12.6python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.6python3.10.____cpython.yaml
@@ -23,14 +23,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.10.* *_cpython
 target_platform:
 - linux-64
 zip_keys:
 - - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
-  - docker_image
 zlib:
 - '1'
 zstd:

--- a/.ci_support/linux_64_cuda_compiler_version12.6python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.6python3.11.____cpython.yaml
@@ -23,14 +23,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.11.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
-  - docker_image
 zlib:
 - '1'
 zstd:

--- a/.ci_support/linux_64_cuda_compiler_version12.6python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.6python3.12.____cpython.yaml
@@ -23,14 +23,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.12.* *_cpython
 target_platform:
 - linux-64
 zip_keys:
 - - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
-  - docker_image
 zlib:
 - '1'
 zstd:

--- a/.ci_support/linux_64_cuda_compiler_version12.6python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.6python3.13.____cp313.yaml
@@ -23,14 +23,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.13.* *_cp313
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
-  - docker_image
 zlib:
 - '1'
 zstd:

--- a/.ci_support/linux_64_cuda_compiler_version12.6python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version12.6python3.9.____cpython.yaml
@@ -23,14 +23,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - linux-64
 zip_keys:
 - - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
-  - docker_image
 zlib:
 - '1'
 zstd:

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.10.____cpython.yaml
@@ -28,9 +28,7 @@ target_platform:
 - linux-aarch64
 zip_keys:
 - - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
-  - docker_image
 zlib:
 - '1'
 zstd:

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.11.____cpython.yaml
@@ -23,14 +23,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.13.* *_cp313
+- 3.11.* *_cpython
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
-  - docker_image
 zlib:
 - '1'
 zstd:

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.12.____cpython.yaml
@@ -25,12 +25,10 @@ pin_run_as_build:
 python:
 - 3.12.* *_cpython
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
-  - docker_image
 zlib:
 - '1'
 zstd:

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.13.____cp313.yaml
@@ -23,14 +23,12 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.11.* *_cpython
+- 3.13.* *_cp313
 target_platform:
 - linux-aarch64
 zip_keys:
 - - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
-  - docker_image
 zlib:
 - '1'
 zstd:

--- a/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version12.6python3.9.____cpython.yaml
@@ -28,9 +28,7 @@ target_platform:
 - linux-aarch64
 zip_keys:
 - - cxx_compiler_version
-  - cuda_compiler
   - cuda_compiler_version
-  - docker_image
 zlib:
 - '1'
 zstd:

--- a/README.md
+++ b/README.md
@@ -34,73 +34,73 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython</td>
+              <td>linux_64_cuda_compiler_version12.6python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15875&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_version12.6python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython</td>
+              <td>linux_64_cuda_compiler_version12.6python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15875&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_version12.6python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython</td>
+              <td>linux_64_cuda_compiler_version12.6python3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15875&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_version12.6python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313</td>
+              <td>linux_64_cuda_compiler_version12.6python3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15875&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_version12.6python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.9.____cpython</td>
+              <td>linux_64_cuda_compiler_version12.6python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15875&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_version12.6python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython</td>
+              <td>linux_aarch64_cuda_compiler_version12.6python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15875&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.6python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython</td>
+              <td>linux_aarch64_cuda_compiler_version12.6python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15875&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.6python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython</td>
+              <td>linux_aarch64_cuda_compiler_version12.6python3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15875&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.6python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313</td>
+              <td>linux_aarch64_cuda_compiler_version12.6python3.13.____cp313</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15875&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.13.____cp313" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.6python3.13.____cp313" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.9.____cpython</td>
+              <td>linux_aarch64_cuda_compiler_version12.6python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=15875&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/triton-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.6python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/build-locally.py
+++ b/build-locally.py
@@ -106,9 +106,7 @@ def main(args=None):
         action="store_true",
         help="Setup debug environment using `conda debug`",
     )
-    p.add_argument(
-        "--output-id", help="If running debug, specify the output to setup."
-    )
+    p.add_argument("--output-id", help="If running debug, specify the output to setup.")
 
     ns = p.parse_args(args=args)
     verify_config(ns)
@@ -124,9 +122,7 @@ def main(args=None):
         elif ns.config.startswith("win"):
             run_win_build(ns)
     finally:
-        recipe_license_file = os.path.join(
-            "recipe", "recipe-scripts-license.txt"
-        )
+        recipe_license_file = os.path.join("recipe", "recipe-scripts-license.txt")
         if os.path.exists(recipe_license_file):
             os.remove(recipe_license_file)
 

--- a/recipe/patches/0001-Remove-Werror-that-cause-false-positive-build-failur.patch
+++ b/recipe/patches/0001-Remove-Werror-that-cause-false-positive-build-failur.patch
@@ -1,7 +1,7 @@
-From 5b674864b9f71718c5f569005198c02cb513fc09 Mon Sep 17 00:00:00 2001
+From 2f91e94506f7c67a71e9bc18f3fd3ffdb0ac70f2 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
 Date: Wed, 20 Nov 2024 17:17:18 +0100
-Subject: [PATCH 1/4] Remove -Werror that cause false-positive build failures
+Subject: [PATCH 1/5] Remove -Werror that cause false-positive build failures
 
 ---
  CMakeLists.txt | 2 +-

--- a/recipe/patches/0002-Do-not-link-directly-to-LLVM-static-libraries.patch
+++ b/recipe/patches/0002-Do-not-link-directly-to-LLVM-static-libraries.patch
@@ -1,7 +1,7 @@
-From 6a61c8c08e4f06cf07a5e6b8be154d37007f8a45 Mon Sep 17 00:00:00 2001
+From 116f1f5cd080f99e946bedb748e6e5b25613c893 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
 Date: Thu, 21 Nov 2024 15:02:04 +0100
-Subject: [PATCH 2/4] Do not link directly to LLVM static libraries
+Subject: [PATCH 2/5] Do not link directly to LLVM static libraries
 
 Remove direct linking to LLVM static libraries, use the shared library
 enforced by MLIR instead.  It is incorrect to simultaneously link to

--- a/recipe/patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
+++ b/recipe/patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
@@ -1,7 +1,7 @@
-From ce626d7727aaeb89f8435708557aa36aae6487eb Mon Sep 17 00:00:00 2001
+From 9f893340cd1b66b3f9f4fdde10f607d21c9b321d Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
 Date: Tue, 26 Nov 2024 11:58:06 +0100
-Subject: [PATCH 3/4] Use system PATH to find tools (in CONDA_PREFIX)
+Subject: [PATCH 3/5] Use system PATH to find tools (in CONDA_PREFIX)
 
 ---
  python/triton/backends/compiler.py     | 2 ++

--- a/recipe/patches/0004-Add-conda-forge-include-dirs-to-list-of-include-dirs.patch
+++ b/recipe/patches/0004-Add-conda-forge-include-dirs-to-list-of-include-dirs.patch
@@ -1,7 +1,7 @@
-From c3dea336d591b0e3ce656217fe41aefd6d0b6487 Mon Sep 17 00:00:00 2001
+From f038196fcce641dfe63abd683c02f25380af2ea3 Mon Sep 17 00:00:00 2001
 From: Mark Harfouche <mark.harfouche@gmail.com>
 Date: Sat, 11 Jan 2025 22:33:48 -0500
-Subject: [PATCH 4/4] Add conda-forge include dirs to list of include dirs
+Subject: [PATCH 4/5] Add conda-forge include dirs to list of include dirs
  during compilation
 
 ---

--- a/recipe/patches/0005-fixes-definition-of-PY_SSIZE_T_CLEAN-macro.patch
+++ b/recipe/patches/0005-fixes-definition-of-PY_SSIZE_T_CLEAN-macro.patch
@@ -1,0 +1,24 @@
+From 7b810e558ea7fce9e19356c634feb41167127119 Mon Sep 17 00:00:00 2001
+From: Aditya Mayukh Som <adi.kg2@gmail.com>
+Date: Sat, 24 May 2025 20:05:24 +0000
+Subject: [PATCH 5/5] fixes definition of PY_SSIZE_T_CLEAN macro
+
+[removed unnecessary changes]
+
+Co-Authored-By: H. Vetinari <h.vetinari@gmx.com>
+---
+ third_party/nvidia/backend/driver.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/third_party/nvidia/backend/driver.py b/third_party/nvidia/backend/driver.py
+index 5f2621ae5..3c59f2df5 100644
+--- a/third_party/nvidia/backend/driver.py
++++ b/third_party/nvidia/backend/driver.py
+@@ -196,6 +196,7 @@ def make_launcher(constants, signature):
+     params = [f"&arg{i}" for i, ty in signature.items() if ty != "constexpr"]
+     params.append("&global_scratch")
+     src = f"""
++#define PY_SSIZE_T_CLEAN
+ #include \"cuda.h\"
+ #include <stdbool.h>
+ #include <Python.h>

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ context:
   version: "3.3.1"
   # cmake/llvm-hash.txt
   llvm_commit: a66376b0dc3b2ea8a84fda26faca287980986f78
-  build_number: 0
+  build_number: 1
 
 package:
   name: triton
@@ -18,6 +18,8 @@ source:
       - patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
       # https://github.com/conda-forge/pytorch-cpu-feedstock/issues/317#issuecomment-2585460619
       - patches/0004-Add-conda-forge-include-dirs-to-list-of-include-dirs.patch
+      # backport (relevant parts of) https://github.com/triton-lang/triton/pull/6928
+      - patches/0005-fixes-definition-of-PY_SSIZE_T_CLEAN-macro.patch
   - url: https://github.com/llvm/llvm-project/archive/${{ llvm_commit }}.tar.gz
     sha256: 10eb1d36aabbc5d31c9d2af27844f51638d40be28975a4ab20ad13609f7da23d
     target_directory: llvm-project


### PR DESCRIPTION
Backport https://github.com/triton-lang/triton/pull/6928 for issues on pytorch feedstock (e.g. https://github.com/conda-forge/pytorch-cpu-feedstock/pull/393)