### PR TITLE
Make conda-forge package work out-of-the-box in Blackwell systems

### DIFF
--- a/recipe/patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
+++ b/recipe/patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
@@ -1,17 +1,8 @@
-From 49c0a665329a822217f3788ce52ace0081797fda Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@quansight.com>
-Date: Fri, 1 Aug 2025 13:31:58 +0200
-Subject: [PATCH 3/4] Use system PATH to find tools (in CONDA_PREFIX)
-
----
- python/triton/knobs.py | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
-
 diff --git a/python/triton/knobs.py b/python/triton/knobs.py
-index b55bd3de3..cb3fca013 100644
+index b55bd3de32..677378f9f4 100644
 --- a/python/triton/knobs.py
 +++ b/python/triton/knobs.py
-@@ -4,6 +4,7 @@ import functools
+@@ -4,6 +4,7 @@
  import importlib
  import os
  import re
@@ -19,7 +10,7 @@ index b55bd3de3..cb3fca013 100644
  import subprocess
  import sysconfig
  import pathlib
-@@ -205,12 +206,11 @@ class env_nvidia_tool(env_base[str, NvidiaTool]):
+@@ -205,12 +206,22 @@ def get(self) -> NvidiaTool:
      def transform(self, path: str) -> NvidiaTool:
          # We still add default as fallback in case the pointed binary isn't
          # accessible.
@@ -28,6 +19,17 @@ index b55bd3de3..cb3fca013 100644
 -        else:
 -            paths = [self.default_path]
 +        paths = [path, self.default_path, shutil.which(self.binary)]
++
++        # Conda-forge triton's package:
++        # - depends on recent enough cuda-nvcc-tools, providing suitable ptxas for blackwell.
++        # - does not ship triton's custom ptxas-blackwell.
++        # This heuristic allows conda-forge's triton to work out-of-the-box in blackwell systems.
++        # Lowest priority means no behavior change in other circunstances.
++        # Fixes https://github.com/conda-forge/triton-feedstock/issues/67
++        if str(self.binary).endswith('ptxas-blackwell'):
++            if os.environ.get("CONDA_PREFIX") is not None:
++                conda_path = os.path.join(os.environ["CONDA_PREFIX"], "bin", "ptxas")
++                paths.append(conda_path)
  
          for path in paths:
 +            if path is None:
@@ -35,6 +37,3 @@ index b55bd3de3..cb3fca013 100644
              if tool := NvidiaTool.from_path(path):
                  return tool
  
--- 
-2.53.0
-

--- a/recipe/patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
+++ b/recipe/patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
@@ -1,5 +1,14 @@
+From 4ee1c4a041c6b956ae56532b85b8405603ba940a Mon Sep 17 00:00:00 2001
+From: Santi Villalba <sdvillal@gmail.com>
+Date: Fri, 15 May 2026 16:13:41 +0200
+Subject: [PATCH] Use system PATH to find tools (in CONDA_PREFIX)
+
+---
+ python/triton/knobs.py | 19 +++++++++++++++----
+ 1 file changed, 15 insertions(+), 4 deletions(-)
+
 diff --git a/python/triton/knobs.py b/python/triton/knobs.py
-index b55bd3de32..677378f9f4 100644
+index b55bd3de32..d49d523e20 100644
 --- a/python/triton/knobs.py
 +++ b/python/triton/knobs.py
 @@ -4,6 +4,7 @@

--- a/recipe/patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
+++ b/recipe/patches/0003-Use-system-PATH-to-find-tools-in-CONDA_PREFIX.patch
@@ -24,7 +24,7 @@ index b55bd3de32..677378f9f4 100644
 +        # - depends on recent enough cuda-nvcc-tools, providing suitable ptxas for blackwell.
 +        # - does not ship triton's custom ptxas-blackwell.
 +        # This heuristic allows conda-forge's triton to work out-of-the-box in blackwell systems.
-+        # Lowest priority means no behavior change in other circunstances.
++        # Lowest priority means no behavior change in other circumstances.
 +        # Fixes https://github.com/conda-forge/triton-feedstock/issues/67
 +        if str(self.binary).endswith('ptxas-blackwell'):
 +            if os.environ.get("CONDA_PREFIX") is not None:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ context:
   version: "3.6.0"
   # cmake/llvm-hash.txt
   llvm_commit: f6ded0be897e2878612dd903f7e8bb85448269e5
-  build_number: 1
+  build_number: 2
 
 package:
   name: triton


### PR DESCRIPTION
Closes #67.

Allows conda-forge triton to work out-of-the-box in Blackwell systems.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.