### PR TITLE
Strip symbols at link time to reduce package size

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -83,4 +83,9 @@ export LLVM_SYSPATH=$PWD/llvm-project/build
 export LLVM_INCLUDE_DIRS=$LLVM_SYSPATH/include
 export LLVM_LIBRARY_DIR=$LLVM_SYSPATH/lib
 
+# Strip symbols at link time to shrink the package: the default build type
+# is TritonRelBuildWithAsserts (-O2 -g) and rattler-build does not strip in
+# post-processing. Append to LDFLAGS to keep conda's linker flags intact.
+export LDFLAGS="${LDFLAGS} -Wl,-s"
+
 $PYTHON -m pip install . -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,6 +26,11 @@ export MAX_JOBS=$CPU_COUNT
 # no easy way of passing this, not really worth a whole patch
 sed -i -e '/TRITON_BUILD_UT/s:\bON:OFF:' CMakeLists.txt
 
+# don't emit debug info for triton's own objects: it's stripped from the
+# final library anyway (-Wl,-s below), so generating it just wastes build
+# disk and link memory. LLVM is already built without -g (Release).
+sed -i -e '/FLAGS_TRITONRELBUILDWITHASSERTS/s: -g::' CMakeLists.txt
+
 CMAKE_HOST_ARGS=(
     -DCMAKE_BUILD_TYPE=Release
     -DLLVM_BUILD_UTILS=ON
@@ -83,9 +88,9 @@ export LLVM_SYSPATH=$PWD/llvm-project/build
 export LLVM_INCLUDE_DIRS=$LLVM_SYSPATH/include
 export LLVM_LIBRARY_DIR=$LLVM_SYSPATH/lib
 
-# Strip symbols at link time to shrink the package: the default build type
-# is TritonRelBuildWithAsserts (-O2 -g) and rattler-build does not strip in
-# post-processing. Append to LDFLAGS to keep conda's linker flags intact.
+# Strip symbols at link time to shrink the package: statically-linked LLVM
+# adds a large symbol table to libtriton.so, and rattler-build does not
+# strip in post-processing. Append to LDFLAGS to keep conda's flags intact.
 export LDFLAGS="${LDFLAGS} -Wl,-s"
 
 $PYTHON -m pip install . -vv

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ context:
   version: "3.7.1"
   # cmake/llvm-hash.txt
   llvm_commit: 1f126a6dea50d185c0781743a667390037ae88bd
-  build_number: 0
+  build_number: 1
 
 package:
   name: triton


### PR DESCRIPTION
As discussed in https://github.com/conda-forge/pytorch-cpu-feedstock/issues/516#issuecomment-4741200464 the triton binaries can be slimmed down considerably.

The default build type TritonRelBuildWithAsserts compiles with -O2 -g, so libtriton.so otherwise ships full DWARF debug info, and rattler-build does not strip in post-processing. Append -Wl,-s to LDFLAGS so the linker drops symbols and debug info while keeping conda's existing linker flags. 

Running in CI should show how much of a difference this makes. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
